### PR TITLE
Adds usbstate, usbenable, usbdisable to obmcutil

### DIFF
--- a/bmc_state_manager.cpp
+++ b/bmc_state_manager.cpp
@@ -230,6 +230,15 @@ BMC::BMCState BMC::currentBMCState(BMCState value)
     return server::BMC::currentBMCState(value);
 }
 
+BMC::USBState BMC::currentUSBState(USBState value)
+{
+    log<level::INFO>(
+        "Setting the USBState field",
+        entry("CURRENT_USB_STATE=0x%s", convertForMessage(value).c_str()));
+
+    return server::BMC::currentUSBState(value);
+}
+
 uint64_t BMC::lastRebootTime() const
 {
     using namespace std::chrono;

--- a/bmc_state_manager.hpp
+++ b/bmc_state_manager.hpp
@@ -52,6 +52,9 @@ class BMC : public BMCInherit
     /** @brief Set value of CurrentBMCState **/
     BMCState currentBMCState(BMCState value) override;
 
+    /** @brief Set value of CurrentUSBState **/
+    USBState currentUSBState(USBState value) override;
+
     /** @brief Returns the last time the BMC was rebooted
      *
      *  @details Uses uptime information to determine when

--- a/obmcutil
+++ b/obmcutil
@@ -4,7 +4,8 @@ set -euo pipefail
 
 OPTS="bmcstate,bootprogress,chassiskill,chassisoff,chassison,chassisstate,hoststate,\
 osstate,power,poweroff,poweron,state,status,hostrebootoff,hostrebooton,recoveryoff,recoveryon,\
-bmcrebootoff, bmcrebooton, listbootblock listlogs showlog deletelogs"
+bmcrebootoff, bmcrebooton, listbootblock listlogs showlog deletelogs, \
+usbstate, usbenable, usbdisable"
 
 USAGE="Usage: obmcutil [-h] [--wait] [--verbose]
                 {$OPTS}"
@@ -331,6 +332,33 @@ handle_cmd ()
             PROPERTY=CurrentBMCState
             state_query "$SERVICE" $OBJECT $INTERFACE $PROPERTY
             ;;
+        usbstate)
+            OBJECT=$STATE_OBJECT/bmc0
+            SERVICE=$(mapper get-service $OBJECT)
+            INTERFACE=$STATE_INTERFACE.BMC
+            PROPERTY=CurrentUSBState
+            state_query "$SERVICE" $OBJECT $INTERFACE $PROPERTY
+            ;;
+        usbdisable)
+            OBJECT=$STATE_OBJECT/bmc0
+            SERVICE=$(mapper get-service $OBJECT)
+            INTERFACE=$STATE_INTERFACE.BMC
+            PROPERTY=RequestedBMCTransition
+            VALUE=$INTERFACE.Transition.DisableUsb
+            G_REQUESTED_STATE=$INTERFACE.USBState.UsbDisabled
+            G_QUERY="usbstate"
+            set_property "$SERVICE" $OBJECT $INTERFACE $PROPERTY "s" $VALUE
+            ;;
+        usbenable)
+            OBJECT=$STATE_OBJECT/bmc0
+            SERVICE=$(mapper get-service $OBJECT)
+            INTERFACE=$STATE_INTERFACE.BMC
+            PROPERTY=RequestedBMCTransition
+            VALUE=$INTERFACE.Transition.EnableUsb
+            G_REQUESTED_STATE=$INTERFACE.USBState.UsbEnabled
+            G_QUERY="usbstate"
+            set_property "$SERVICE" $OBJECT $INTERFACE $PROPERTY "s" $VALUE
+            ;;
         chassisstate)
             OBJECT=$STATE_OBJECT/chassis0
             SERVICE=$(mapper get-service $OBJECT)
@@ -353,7 +381,7 @@ handle_cmd ()
             state_query "$SERVICE" $OBJECT $INTERFACE $PROPERTY
             ;;
         state|status)
-            for query in bmcstate chassisstate hoststate bootprogress osstate
+            for query in bmcstate usbstate chassisstate hoststate bootprogress osstate
             do
                 handle_cmd $query
             done


### PR DESCRIPTION
Now the BMC's USB port can be checked with usbstate as well as
Enabled or Disabled with usbenable or usbdisable via obmcutil.

Tested: On QEMU and Rainier for BMC's USB port control.
This is to unblock Redfish: USB Port Enable / Disable #1781
https://github.com/ibm-openbmc/dev/issues/1781

Further work is still needed.